### PR TITLE
Revert "refactor(s3): replace hardcoded Tencent COS detection with extensible endpoint strategy pattern"

### DIFF
--- a/apps/core/src/utils/s3.util.spec.ts
+++ b/apps/core/src/utils/s3.util.spec.ts
@@ -1,11 +1,7 @@
 import * as crypto from 'node:crypto'
-import type { S3EndpointContext, S3UploaderOptions } from '~/utils/s3.util'
-import {
-  DefaultS3EndpointStrategy,
-  S3Uploader,
-  TencentCosEndpointStrategy,
-} from '~/utils/s3.util'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { S3UploaderOptions } from './s3.util'
+import { S3Uploader } from './s3.util'
 
 // Mock fetch
 global.fetch = vi.fn()
@@ -161,131 +157,6 @@ describe('S3Uploader', () => {
           method: 'PUT',
           body: mockBuffer,
         }),
-      )
-    })
-  })
-
-  describe('TencentCosEndpointStrategy', () => {
-    const strategy = new TencentCosEndpointStrategy()
-
-    it('should match myqcloud.com hosts', () => {
-      expect(strategy.matches('cos.ap-guangzhou.myqcloud.com', 'bucket')).toBe(
-        true,
-      )
-    })
-
-    it('should match hosts containing .cos.', () => {
-      expect(
-        strategy.matches('bucket.cos.ap-guangzhou.myqcloud.com', 'bucket'),
-      ).toBe(true)
-    })
-
-    it('should not match generic S3 hosts', () => {
-      expect(strategy.matches('s3.amazonaws.com', 'bucket')).toBe(false)
-      expect(strategy.matches('test-endpoint.com', 'bucket')).toBe(false)
-    })
-
-    it('should convert cos.region.myqcloud.com to virtual-hosted style', () => {
-      const context: S3EndpointContext = {
-        protocol: 'https:',
-        host: 'cos.ap-guangzhou.myqcloud.com',
-        bucket: 'my-bucket',
-        endpoint: 'https://cos.ap-guangzhou.myqcloud.com',
-        encodedObjectKey: 'folder/file.png',
-      }
-      const result = strategy.resolve(context)
-      expect(result.requestHost).toBe('my-bucket.cos.ap-guangzhou.myqcloud.com')
-      expect(result.canonicalUri).toBe('/folder/file.png')
-      expect(result.baseUrl).toBe(
-        'https://my-bucket.cos.ap-guangzhou.myqcloud.com',
-      )
-    })
-
-    it('should keep existing requestHost when host does not match cos.* pattern', () => {
-      const context: S3EndpointContext = {
-        protocol: 'https:',
-        host: 'my-bucket.cos.ap-guangzhou.myqcloud.com',
-        bucket: 'my-bucket',
-        endpoint: 'https://my-bucket.cos.ap-guangzhou.myqcloud.com',
-        encodedObjectKey: 'folder/file.png',
-      }
-      const result = strategy.resolve(context)
-      expect(result.requestHost).toBe('my-bucket.cos.ap-guangzhou.myqcloud.com')
-      expect(result.canonicalUri).toBe('/folder/file.png')
-    })
-  })
-
-  describe('DefaultS3EndpointStrategy', () => {
-    const strategy = new DefaultS3EndpointStrategy()
-
-    it('should always match', () => {
-      expect(strategy.matches('anything.com', 'any-bucket')).toBe(true)
-    })
-
-    it('should use virtual-hosted style when host starts with bucket name', () => {
-      const context: S3EndpointContext = {
-        protocol: 'https:',
-        host: 'my-bucket.s3.us-east-1.amazonaws.com',
-        bucket: 'my-bucket',
-        endpoint: 'https://my-bucket.s3.us-east-1.amazonaws.com',
-        encodedObjectKey: 'folder/file.png',
-      }
-      const result = strategy.resolve(context)
-      expect(result.requestHost).toBe('my-bucket.s3.us-east-1.amazonaws.com')
-      expect(result.canonicalUri).toBe('/folder/file.png')
-      expect(result.baseUrl).toBe(context.endpoint)
-    })
-
-    it('should use path style when host does not start with bucket name', () => {
-      const context: S3EndpointContext = {
-        protocol: 'https:',
-        host: 's3.us-east-1.amazonaws.com',
-        bucket: 'my-bucket',
-        endpoint: 'https://s3.us-east-1.amazonaws.com',
-        encodedObjectKey: 'folder/file.png',
-      }
-      const result = strategy.resolve(context)
-      expect(result.requestHost).toBe('s3.us-east-1.amazonaws.com')
-      expect(result.canonicalUri).toBe('/my-bucket/folder/file.png')
-      expect(result.baseUrl).toBe(context.endpoint)
-    })
-  })
-
-  describe('registerStrategy', () => {
-    it('should apply a custom strategy before the default one', async () => {
-      const customStrategy = {
-        matches: (host: string) => host === 'custom-provider.com',
-        resolve: (ctx: S3EndpointContext) => ({
-          requestHost: ctx.host,
-          canonicalUri: `/custom/${ctx.encodedObjectKey}`,
-          baseUrl: ctx.endpoint,
-        }),
-      }
-
-      const customUploader = new S3Uploader({
-        ...options,
-        endpoint: 'https://custom-provider.com',
-      })
-      customUploader.registerStrategy(customStrategy)
-
-      await customUploader.uploadToS3('test-object', mockBuffer, 'text/plain')
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/custom/test-object'),
-        expect.anything(),
-      )
-    })
-
-    it('should fall back to default strategy when no custom strategy matches', async () => {
-      const nonMatchingStrategy = {
-        matches: () => false,
-        resolve: () => ({ requestHost: 'x', canonicalUri: '/x', baseUrl: 'x' }),
-      }
-      uploader.registerStrategy(nonMatchingStrategy)
-
-      await uploader.uploadToS3('test-object', mockBuffer, 'text/plain')
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('/test-bucket/test-object'),
-        expect.anything(),
       )
     })
   })

--- a/apps/core/src/utils/s3.util.ts
+++ b/apps/core/src/utils/s3.util.ts
@@ -9,112 +9,12 @@ export interface S3UploaderOptions {
   endpoint?: string
 }
 
-export interface S3EndpointContext {
-  protocol: string
-  host: string
-  bucket: string
-  endpoint: string
-  encodedObjectKey: string
-}
-
-export interface S3EndpointResolution {
-  requestHost: string
-  canonicalUri: string
-  baseUrl: string
-}
-
-export interface S3EndpointStrategy {
-  matches: (host: string, bucket: string) => boolean
-  resolve: (context: S3EndpointContext) => S3EndpointResolution
-}
-
-export class TencentCosEndpointStrategy implements S3EndpointStrategy {
-  matches(host: string): boolean {
-    return (
-      host === 'myqcloud.com' ||
-      host.endsWith('.myqcloud.com') ||
-      host.includes('.cos.')
-    )
-  }
-
-  resolve({
-    protocol,
-    host,
-    bucket,
-    encodedObjectKey,
-  }: S3EndpointContext): S3EndpointResolution {
-    let requestHost = host
-    const cosMatch = host.match(/^cos\.(.+)$/)
-    if (cosMatch) {
-      requestHost = `${bucket}.cos.${cosMatch[1]}`
-    }
-    return {
-      requestHost,
-      canonicalUri: `/${encodedObjectKey}`,
-      baseUrl: `${protocol}//${requestHost}`,
-    }
-  }
-}
-
-export class DefaultS3EndpointStrategy implements S3EndpointStrategy {
-  matches(_host: string, _bucket: string): boolean {
-    return true
-  }
-
-  resolve({
-    host,
-    bucket,
-    endpoint,
-    encodedObjectKey,
-  }: S3EndpointContext): S3EndpointResolution {
-    const isVirtualHosted = host.startsWith(`${bucket}.`)
-    return {
-      requestHost: host,
-      canonicalUri: isVirtualHosted
-        ? `/${encodedObjectKey}`
-        : `/${bucket}/${encodedObjectKey}`,
-      baseUrl: endpoint,
-    }
-  }
-}
-
 export class S3Uploader {
   private options: S3UploaderOptions
   private customDomain: string = ''
-  private strategies: S3EndpointStrategy[] = [
-    new TencentCosEndpointStrategy(),
-    new DefaultS3EndpointStrategy(),
-  ]
 
   constructor(options: S3UploaderOptions) {
     this.options = options
-  }
-
-  registerStrategy(strategy: S3EndpointStrategy): this {
-    // Insert before the default (fallback) strategy, which is always last
-    this.strategies.splice(this.strategies.length - 1, 0, strategy)
-    return this
-  }
-
-  private resolveEndpoint(
-    url: URL,
-    encodedObjectKey: string,
-  ): S3EndpointResolution {
-    const context: S3EndpointContext = {
-      protocol: url.protocol,
-      host: url.host,
-      bucket: this.bucket,
-      endpoint: this.endpoint,
-      encodedObjectKey,
-    }
-    for (const strategy of this.strategies) {
-      if (strategy.matches(url.host, this.bucket)) {
-        return strategy.resolve(context)
-      }
-    }
-    // Unreachable: DefaultS3EndpointStrategy always matches
-    /* c8 ignore next */
-    return new DefaultS3EndpointStrategy().resolve(context)
   }
 
   get endpoint(): string {
@@ -210,6 +110,9 @@ export class S3Uploader {
 
     // Set request headers
     const url = new URL(this.endpoint)
+    const host = url.host
+    let requestHost = host
+    let canonicalUri: string
 
     // URI encode each path segment for signing
     const encodedObjectKey = objectKey
@@ -217,10 +120,25 @@ export class S3Uploader {
       .map((seg) => encodeURIComponent(seg))
       .join('/')
 
-    const { requestHost, canonicalUri, baseUrl } = this.resolveEndpoint(
-      url,
-      encodedObjectKey,
-    )
+    // Determine canonical URI based on endpoint style
+    // For Tencent COS and other services that require virtual-hosted style
+    const isTencentCos = host.includes('myqcloud.com') || host.includes('.cos.')
+
+    if (isTencentCos) {
+      // Tencent COS requires virtual-hosted style
+      // Convert cos.ap-guangzhou.myqcloud.com to bucket.cos.ap-guangzhou.myqcloud.com
+      const cosMatch = host.match(/^cos\.(.+)$/)
+      if (cosMatch) {
+        requestHost = `${this.bucket}.cos.${cosMatch[1]}`
+      }
+      canonicalUri = `/${encodedObjectKey}`
+    } else {
+      // Check if already in virtual-hosted style
+      const isVirtualHosted = host.startsWith(`${this.bucket}.`)
+      canonicalUri = isVirtualHosted
+        ? `/${encodedObjectKey}`
+        : `/${this.bucket}/${encodedObjectKey}`
+    }
 
     const contentLength = fileData.length.toString()
 
@@ -277,6 +195,10 @@ export class S3Uploader {
     const authorization = `${algorithm} Credential=${this.accessKey}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`
 
     // Create and send PUT request
+    // For Tencent COS, use virtual-hosted style URL
+    const baseUrl = isTencentCos
+      ? `${url.protocol}//${requestHost}`
+      : this.endpoint
     const requestUrl = `${baseUrl}${canonicalUri}`
 
     const fetchOptions: RequestInit & { dispatcher?: unknown } = {


### PR DESCRIPTION
Reverts sysfox/mx-space-core#11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified S3 upload endpoint resolution by consolidating strategy-based logic into inline implementation. Endpoint handling for Tencent COS and standard S3 services is now processed directly within the upload method for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->